### PR TITLE
Update patch.py

### DIFF
--- a/yaml_patch/patch.py
+++ b/yaml_patch/patch.py
@@ -61,10 +61,10 @@ def patch_yaml(yaml_contents: str, patches: Sequence[str]) -> str:
     yamlparser = YAML()
     for p in patches:
         if "+=" in p:
-            path, value = p.split("+=")
+            path, value = p.split("+=", maxsplit=1)
             action = _patch._action_append
         else:
-            path, value = p.split("=")
+            path, value = p.split("=", maxsplit=1)
             action = _patch._action_set
 
         _apply_patch(parsed, path, action, yamlparser.load(value))


### PR DESCRIPTION
add maxsplit argument to split function
p.split("+=", maxsplit=1)
because if incoming sting will be like 
- RECIPIENTS_DB_URL=:r2dbc:postgresql://postgresql.host:postgresql.port/db_info?currentSchema=public -
Logicaly in code expected to get only 2 parameters, therefome it is needed to explicit to set maxsplit to avoid errors